### PR TITLE
don't use Dancer2 ':syntax';

### DIFF
--- a/lib/Dancer2/Plugin/Chain.pm
+++ b/lib/Dancer2/Plugin/Chain.pm
@@ -17,7 +17,6 @@ use 5.006;
 use strict; use warnings;
 use Data::Dumper;
 
-use Dancer2 ':syntax';
 use Dancer2::Plugin;
 use Dancer2::Plugin::Chain::Router;
 


### PR DESCRIPTION
With current master branch of Dancer2 (to be released soon) plugins break if they import Dancer2 itself.

Apologies for all the PRs that are caused by Dancer2 changes.
